### PR TITLE
Refactor entry point and config loading

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -1,24 +1,44 @@
+"""Configuration module.
+
+Environment variables are loaded from a local ``.env`` file on import so that
+the ``Cfg`` class below reflects those values immediately. Boolean values use a
+helper that understands common truthy strings.
+"""
+
+from dotenv import load_dotenv
 import os
-def _b(k, d): return str(os.getenv(k, d)).strip().lower() in ("1","true","yes","on")
+
+
+load_dotenv()
+
+
+def _b(key: str, default) -> bool:
+    """Parse an environment variable as a boolean."""
+
+    return str(os.getenv(key, default)).strip().lower() in ("1", "true", "yes", "on")
+
+
 class Cfg:
-    BROKER_MODE = os.getenv("BROKER_MODE","live")
+    """Configuration values used throughout the bot."""
+
+    BROKER_MODE = os.getenv("BROKER_MODE", "live")
     DRY_RUN = _b("DRY_RUN", True)
-    EQUITY_USD = float(os.getenv("EQUITY_USD","5000"))
-    API_KEY_BINANCE = os.getenv("API_KEY_BINANCE","")
-    API_SECRET_BINANCE = os.getenv("API_SECRET_BINANCE","")
-    API_KEY_BYBIT = os.getenv("API_KEY_BYBIT","")
-    API_SECRET_BYBIT = os.getenv("API_SECRET_BYBIT","")
-    SYMBOL = os.getenv("SYMBOL","BTC/USDT")
-    POLL_SECONDS = int(os.getenv("POLL_SECONDS","900"))
-    ORDER_SIZE_USD = float(os.getenv("ORDER_SIZE_USD","50.0"))
-    VENUE_EXPOSURE_CAP_PCT = float(os.getenv("VENUE_EXPOSURE_CAP_PCT","40"))
-    MIN_CARRY_APR = float(os.getenv("MIN_CARRY_APR","8.0"))
+    EQUITY_USD = float(os.getenv("EQUITY_USD", "5000"))
+    API_KEY_BINANCE = os.getenv("API_KEY_BINANCE", "")
+    API_SECRET_BINANCE = os.getenv("API_SECRET_BINANCE", "")
+    API_KEY_BYBIT = os.getenv("API_KEY_BYBIT", "")
+    API_SECRET_BYBIT = os.getenv("API_SECRET_BYBIT", "")
+    SYMBOL = os.getenv("SYMBOL", "BTC/USDT")
+    POLL_SECONDS = int(os.getenv("POLL_SECONDS", "900"))
+    ORDER_SIZE_USD = float(os.getenv("ORDER_SIZE_USD", "50.0"))
+    VENUE_EXPOSURE_CAP_PCT = float(os.getenv("VENUE_EXPOSURE_CAP_PCT", "40"))
+    MIN_CARRY_APR = float(os.getenv("MIN_CARRY_APR", "8.0"))
     DYN_CARRY_ENABLED = _b("DYN_CARRY_ENABLED", True)
-    DYN_RAISE5 = float(os.getenv("DYN_RAISE5","10.0"))
-    DYN_RAISE3 = float(os.getenv("DYN_RAISE3","12.0"))
-    DELTA_THRESHOLD_USD = float(os.getenv("DELTA_THRESHOLD_USD","2.5"))
-    DELTA_TOL_PCT = float(os.getenv("DELTA_TOL_PCT","0.5"))
-    ERROR_TRIP_COUNT = int(os.getenv("ERROR_TRIP_COUNT","3"))
-    WATCHDOG_PAUSE_MINUTES = int(os.getenv("WATCHDOG_PAUSE_MINUTES","5"))
-    TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN","")
-    TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID","")
+    DYN_RAISE5 = float(os.getenv("DYN_RAISE5", "10.0"))
+    DYN_RAISE3 = float(os.getenv("DYN_RAISE3", "12.0"))
+    DELTA_THRESHOLD_USD = float(os.getenv("DELTA_THRESHOLD_USD", "2.5"))
+    DELTA_TOL_PCT = float(os.getenv("DELTA_TOL_PCT", "0.5"))
+    ERROR_TRIP_COUNT = int(os.getenv("ERROR_TRIP_COUNT", "3"))
+    WATCHDOG_PAUSE_MINUTES = int(os.getenv("WATCHDOG_PAUSE_MINUTES", "5"))
+    TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
+    TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID", "")

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,50 +1,145 @@
-import time, asyncio, logging, threading
-from dotenv import load_dotenv
+"""Primary entry point for the carry-trading bot.
+
+The original implementation bundled much of the logic onto single lines and
+loaded environment variables only when ``build`` was called.  This module has
+been refactored for readability and to ensure configuration is loaded exactly
+once on import.
+"""
+
+import asyncio
+import logging
+import threading
+import time
+
 from aiohttp import web
+
 from .config import Cfg
-from .metrics import boot_metrics, metrics_updated_ts, min_carry_threshold, errors_total, net_delta_usd
-from .notify import tg
 from .exchanges import Venue
+from .health import build_app
 from .hedger import Hedger
+from .metrics import (
+    boot_metrics,
+    errors_total,
+    metrics_updated_ts,
+    min_carry_threshold,
+    net_delta_usd,
+)
+from .notify import tg
+from .rebalancer import Rebalancer
 from .risk import Watchdog
 from .state import State
-from .health import build_app
-from .rebalancer import Rebalancer
+
+
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
-def build():
-    load_dotenv(); wd=Watchdog(); st=State(); st.load()
-    venues={"binance": Venue("binance","future","spot", Cfg.SYMBOL, f"{Cfg.SYMBOL}:USDT"),
-            "bybit":   Venue("bybit","swap","spot",   Cfg.SYMBOL, f"{Cfg.SYMBOL}:USDT")}
-    hedger=Hedger(venues, st); reb=Rebalancer(venues, get_delta_usd=lambda: 0.0)  # TODO: replace with real delta
-    return hedger, wd, st, venues, reb
-def daily_summary_loop(st):
+
+
+def build() -> tuple[Hedger, Watchdog, State, dict, Rebalancer]:
+    """Initialise core components for the bot."""
+
+    watchdog = Watchdog()
+    state = State()
+    state.load()
+
+    venues = {
+        "binance": Venue("binance", "future", "spot", Cfg.SYMBOL, f"{Cfg.SYMBOL}:USDT"),
+        "bybit": Venue("bybit", "swap", "spot", Cfg.SYMBOL, f"{Cfg.SYMBOL}:USDT"),
+    }
+
+    hedger = Hedger(venues, state)
+    rebalancer = Rebalancer(venues, get_delta_usd=lambda: 0.0)  # TODO: real delta
+
+    return hedger, watchdog, state, venues, rebalancer
+
+
+def daily_summary_loop(state: State) -> None:
+    """Send a daily EMA summary via Telegram."""
+
     while True:
-        now=time.gmtime(); secs=(24-now.tm_hour-1)*3600 + (60-now.tm_min-1)*60 + (60-now.tm_sec) + 5*60
-        time.sleep(secs); ema=st.get_ema(); tg(f"[CRYPTObot] Daily summary {time.strftime('%Y-%m-%d', time.gmtime())}: EMA funding={ema if ema is not None else 0:.2f}%")
-async def aiohttp_main(shared):
-    app=build_app(shared); runner=web.AppRunner(app); await runner.setup(); site=web.TCPSite(runner, "0.0.0.0", 8000); await site.start()
-    while True: await asyncio.sleep(3600)
-def loop_once(hedger, wd):
-    name, carry = hedger.best(); thr=hedger.active_threshold(Cfg.MIN_CARRY_APR); min_carry_threshold.set(thr)
-    if not wd.ok_or_pause(): return
+        now = time.gmtime()
+        secs = (
+            (24 - now.tm_hour - 1) * 3600
+            + (60 - now.tm_min - 1) * 60
+            + (60 - now.tm_sec)
+            + 5 * 60
+        )
+        time.sleep(secs)
+        ema = state.get_ema() or 0.0
+        tg(
+            f"[CRYPTObot] Daily summary {time.strftime('%Y-%m-%d', time.gmtime())}: "
+            f"EMA funding={ema:.2f}%"
+        )
+
+
+async def aiohttp_main(shared: dict) -> None:
+    """Run the HTTP server exposing metrics and health endpoints."""
+
+    app = build_app(shared)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "0.0.0.0", 8000)
+    await site.start()
+    while True:  # pragma: no cover - background server loop
+        await asyncio.sleep(3600)
+
+
+def loop_once(hedger: Hedger, watchdog: Watchdog) -> None:
+    """Execute a single hedging iteration."""
+
+    name, carry = hedger.best()
+    thr = hedger.active_threshold(Cfg.MIN_CARRY_APR)
+    min_carry_threshold.set(thr)
+
+    if not watchdog.ok_or_pause():
+        return
+
     try:
         if hedger.funding_flip(carry) and abs(carry) < thr:
-            tg(f"[CRYPTObot] Funding flip detected. Carry {carry:.2f}% < thr {thr:.2f}%. Holding."); return
-        hedger.enter_if_edge(name, dry=Cfg.DRY_RUN); net_delta_usd.set(0.0)
-    except Exception as e:
-        logging.exception("loop error: %s", e); errors_total.inc(); wd.record_error(e)
+            tg(
+                f"[CRYPTObot] Funding flip detected. Carry {carry:.2f}% < thr {thr:.2f}%. "
+                "Holding."
+            )
+            return
+
+        hedger.enter_if_edge(name, dry=Cfg.DRY_RUN)
+        net_delta_usd.set(0.0)
+    except Exception as exc:  # broad: log and forward to watchdog
+        logging.exception("loop error: %s", exc)
+        errors_total.inc()
+        watchdog.record_error(exc)
     finally:
-        wd.mark_metrics(); metrics_updated_ts.set(time.time())
-def start_rebalancer(reb):
+        watchdog.mark_metrics()
+        metrics_updated_ts.set(time.time())
+
+
+def start_rebalancer(reb: Rebalancer) -> None:
+    """Background thread that triggers a rebalance once per hour."""
+
     while True:
         time.sleep(3600)
-        try: reb.run_once()
-        except Exception as e: logging.warning("Rebalancer error: %s", e)
-if __name__ == "__main__":
-    hedger, wd, st, venues, reb = build(); boot_metrics(8000); tg("[CRYPTObot] started")
-    threading.Thread(target=daily_summary_loop, args=(st,), daemon=True).start()
-    threading.Thread(target=start_rebalancer, args=(reb,), daemon=True).start()
-    shared={"watchdog": wd, "age_limit": int(os.getenv("POLL_SECONDS","900"))*2}
+        try:
+            reb.run_once()
+        except Exception as exc:  # pragma: no cover - log warning
+            logging.warning("Rebalancer error: %s", exc)
+
+
+def main() -> None:
+    """Start the bot and its background tasks."""
+
+    hedger, watchdog, state, venues, rebalancer = build()
+    boot_metrics(8000)
+    tg("[CRYPTObot] started")
+
+    threading.Thread(target=daily_summary_loop, args=(state,), daemon=True).start()
+    threading.Thread(target=start_rebalancer, args=(rebalancer,), daemon=True).start()
+
+    shared = {"watchdog": watchdog, "age_limit": Cfg.POLL_SECONDS * 2}
     asyncio.get_event_loop().create_task(aiohttp_main(shared))
+
     while True:
-        loop_once(hedger, wd); time.sleep(int(os.getenv("POLL_SECONDS","900")))
+        loop_once(hedger, watchdog)
+        time.sleep(Cfg.POLL_SECONDS)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure the repository root is on sys.path so ``import bot`` works
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- load environment variables when importing configuration
- refactor bot's main module into readable functions
- ensure tests can import package by adjusting sys.path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c07ff9a088333b579fd6503c03d24